### PR TITLE
add pypiwin32's version to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,9 @@ python = "^3.7"
 typer = "^0.3.2"
 httpx = "^0.16.1"
 PyYAML = "^5.4.1"
-pydantic = {extras = ["email"], version = "^1.8.1"}
+pydantic = { extras = ["email"], version = "^1.8.1" }
 keyring = "^22.3.0"
-pypiwin32 = {markers = "sys_platform == 'win32'" }
+pypiwin32 = { version = "^223", markers = "sys_platform == 'win32'" }
 
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
closes #10 